### PR TITLE
Browserify Performance Optimization - Caching getScope

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,6 +116,7 @@ module.exports = function (src) {
     }
     
     function getScope (node) {
+        if (node._cachedScope) return node._cachedScope;
         for (
             var p = node;
             !isFunction(p) && p.type !== 'Program';
@@ -123,6 +124,7 @@ module.exports = function (src) {
         );
         var id = idOf(p);
         if (!locals[id]) locals[id] = {};
+        node._cachedScope = id;
         return id;
     }
     


### PR DESCRIPTION
After some benchmarking, it looks like `getScope` is a pretty hot path during first bundle. Here's a stress test client code:

```js
// index.js
require('three')
require('react')
require('react-dom')
require('react-router')
require('react-css-modules')
require('babel-polyfill')
require('gsap')
```

And then a few runs of:

```sh
time browserify index.js > bundle.js
```

Gives us something around:

```sh
real	0m4.446s
user	0m4.547s
sys	0m0.588s
```

With the following PR in place, the bundle time looks something closer to this:

```sh
real	0m3.614s
user	0m3.720s
sys	0m0.531s
```

Which is almost a second faster.

This may be a bit of an edge case and maybe not worth the trouble, just thought it's worth pointing out. :smile: